### PR TITLE
Add clean script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "sourdough",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "license": "MIT",
   "scripts": {
     "prepare": "husky install",
-    "build": "parcel build --public-url ./ src/index.html",
-    "start": "parcel src/index.html"
+    "clean": "rm -rf dist/* && rm -rf .parcel-cache",
+    "build": "yarn clean && parcel build --public-url ./ src/index.html",
+    "start": "yarn clean && parcel src/index.html"
   },
   "dependencies": {
     "react": "^17.0.2",


### PR DESCRIPTION
#### What's this PR do?

- Adds a new yarn script called `clean` which runs `rm -rf dist/* && rm -rf .parcel-cache`. 
- Modifies `start` and `build` scripts to run `clean` first.

#### Why are we doing this? How does it help us?

Parcel will often not invalidate cached files and we have to remove them from `dist` or `.parcel-cache` and restart the server. This makes that process quicker by including it in the `start` and `build` scripts.

#### How should this be manually tested?

#### Are there any smells or added technical debt to note?

No

#### What are relevant issues or links?

#### Have you done the following, if applicable:

* [ ] Performed a self-review of the code?
* [ ] Linted code for good style and standards?
* [ ] Added unit tests?
* [ ] Tested manually on mobile?
* [ ] Checked for performance implications?
* [ ] Checked accessibility?
* [ ] Checked for vulnerabilities with `yarn audit --level=high`?
* [ ] Updated any documentation
