### PR TITLE
Use new name as default auth file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,5 @@ dist-ssr
 
 # Sourdough
 auth.json
+.daily-google-services.json
 src/data

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ That said, you'll probably want to be importing images by using a CDN (e.g. Jetp
 
 ### Fetching from Google Drive
 
-Download our service account credentials file (`auth.json`) and put it in the root of this repository.
+If you haven't already, download our service account credentials file (`.daily-google-services.json`) and put it in the home directory of your computer.
 
 The credentials file will have a `client_email` property. Share your Google Doc or Google Sheet with the value of this property in order to allow permission to fetch.
 

--- a/config.json
+++ b/config.json
@@ -7,13 +7,13 @@
     {
       "id": "",
       "output": "",
-      "auth": "./auth.json"
+      "auth": "~/.daily-google-services.json"
     },
     {
       "id": "",
       "sheetId": "0",
       "output": "",
-      "auth": "./auth.json"
+      "auth": "~/.daily-google-services.json"
     }
   ],
   "GA_MEASUREMENT_ID": ""


### PR DESCRIPTION
#### What's this PR do?

Changes `./auth.json` to `~/.daily-google-services.json` as the default location/name of our Google auth file.

#### Are there any relevant screenshots?

N/A

#### Why are we doing this? How does it help us?

See <https://github.com/MichiganDaily/sourdough/issues/22#issuecomment-1200014670>

#### How should this be manually tested?

Place your auth file in the root directory and try fetching a file with `sink`.

#### Are there any smells or added technical debt to note?

No

#### What are relevant issues or links?

<https://github.com/MichiganDaily/sink/pull/14> needs to be merged first.

#### Have you done the following, if applicable:

* [ ] Performed a self-review of the code?
* [ ] Linted code for good style and standards?
* [ ] Added unit tests?
* [ ] Tested manually on mobile?
* [ ] Checked for performance implications?
* [ ] Checked accessibility?
* [ ] Checked for vulnerabilities with `yarn audit --level=high`?
* [ ] Updated any documentation
